### PR TITLE
Add glob as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "browser-refresh-taglib": "^1.0.3",
     "express": "^4.9.4",
+    "glob": "^7.1.2",
     "lasso": "^2.11.16",
     "lasso-marko": "^2.3.0",
     "marko": "^4.5.0-beta.3"


### PR DESCRIPTION
I was getting

```
~/Code/marko-express (master)$ npm i
added 137 packages, removed 424 packages and moved 23 packages in 7.812s
~/Code/marko-express (master)$ node server.js
module.js:529
    throw err;
    ^

Error: Cannot find module 'glob'
```