### PR TITLE
Upgrade Marko to 4.5.6 and set up browser-refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
     "express": "^4.9.4",
     "lasso": "^2.11.16",
     "lasso-marko": "^2.3.0",
-    "marko": "^4.5.0-beta.3"
+    "marko": "^4.5.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Sample Express-based server app that integrates the marko module for rendering a view",
   "main": "./server.js",
   "scripts": {
+    "dev": "browser-refresh server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -17,6 +18,7 @@
   },
   "homepage": "https://github.com/marko-js-samples/marko-express",
   "dependencies": {
+    "browser-refresh": "^1.7.2",
     "browser-refresh-taglib": "^1.0.3",
     "express": "^4.9.4",
     "lasso": "^2.11.16",


### PR DESCRIPTION
Browser-refresh taglib is included, but the actual executable isn't installed, nor the run hook present.

Upgrade Marko while we're at it.